### PR TITLE
Added capability to copy just the current selection

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1093,7 +1093,7 @@ export default class CopyDocumentAsHTMLPlugin extends Plugin {
 				}
 
 				if (!checking) {
-					this.doCopy(activeView);
+					this.doCopy(activeView, false);
 				}
 
 				return true;


### PR DESCRIPTION
Hello, I wanted to have the ability to copy just the selected text as HTML, and I gave it a try. A couple of functions now have the `onlySelected` parameter, which decides if the whole document should be copied, or just the current selection.

I also added an extra command, `Copy selection as HTML`.

Hope this helps with https://github.com/mvdkwast/obsidian-copy-as-html/issues/18.