### PR TITLE
Add the <!DOCTYPE> declaration and the UTF-8 encoding attribute

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -225,8 +225,8 @@ const MERMAID_STYLESHEET = `
 const htmlTemplate = (stylesheet: string, body: string, title: string) => `<!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>${title}</title>
-  <meta charset="UTF-8">
   <style>
     ${MERMAID_STYLESHEET}
     ${stylesheet}

--- a/main.ts
+++ b/main.ts
@@ -222,9 +222,11 @@ const MERMAID_STYLESHEET = `
 }
 `;
 
-const htmlTemplate = (stylesheet: string, body: string, title: string) => `<html>
+const htmlTemplate = (stylesheet: string, body: string, title: string) => `<!DOCTYPE html>
+<html>
 <head>
   <title>${title}</title>
+  <meta charset="UTF-8">
   <style>
     ${MERMAID_STYLESHEET}
     ${stylesheet}


### PR DESCRIPTION
I suggest adding the lines
```
<!DOCTYPE html>
```
and
```
<meta charset="UTF-8">
```
to the HTML output so that validators don't report errors.